### PR TITLE
Fix browser preflight for payment routes

### DIFF
--- a/src/gateway.js
+++ b/src/gateway.js
@@ -16,7 +16,9 @@ export function createGateway(port = 3404) {
   // CORS
   app.use((req, res, next) => {
     res.header('Access-Control-Allow-Origin', '*');
-    res.header('Access-Control-Allow-Headers', 'Content-Type, X-Agent-Id, X-Chain, X-Payment-Proof');
+    res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.header('Access-Control-Allow-Headers', 'Content-Type, X-Agent-Id, X-Chain, X-Payment-Proof, X-Payment-Amount, X-Buyer-Address, Idempotency-Key');
+    if (req.method === 'OPTIONS') return res.sendStatus(204);
     next();
   });
 

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -36,6 +36,22 @@ describe('Aegis Mesh Gateway (HTTP)', () => {
     assert.equal(data.registered, 'test-svc');
   });
 
+  it('answers browser preflight for payment routes', async () => {
+    const res = await fetch(`http://localhost:${port}/pay`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://example.com',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'Content-Type, X-Agent-Id, X-Chain, X-Payment-Proof, Idempotency-Key',
+      },
+    });
+    assert.equal(res.status, 204);
+    assert.match(res.headers.get('access-control-allow-methods'), /POST/);
+    assert.match(res.headers.get('access-control-allow-methods'), /OPTIONS/);
+    assert.match(res.headers.get('access-control-allow-headers'), /X-Payment-Proof/);
+    assert.match(res.headers.get('access-control-allow-headers'), /Idempotency-Key/);
+  });
+
   it('discovers services', async () => {
     const res = await fetch(`http://localhost:${port}/discover`);
     const data = await res.json();


### PR DESCRIPTION
This makes the root Express gateway answer browser preflight requests before payment route handling.

Why:
- The gateway advertised CORS headers, but an `OPTIONS /pay` request could still fall through instead of returning a 2xx preflight response.
- Browser callers that send payment/proof headers need `OPTIONS` to succeed before they can POST the payment request.

What changed:
- Adds `Access-Control-Allow-Methods: GET, POST, OPTIONS`.
- Adds the payment/idempotency headers used by the gateway to `Access-Control-Allow-Headers`.
- Returns `204` for preflight requests.
- Adds a gateway test covering `OPTIONS /pay`.

Validation:
- `npm test` passes: 46/46.
